### PR TITLE
Remove StaticArrays, HDF5 and GeometricIntegrators dependencies (for now at least)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,11 @@ version = "0.4.0"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-GeometricIntegrators = "dcce2d33-59f6-5b8d-9047-0defad88ae06"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 FFTW = "1"
 OffsetArrays = "1"
-GeometricIntegrators = "0.9"
 Reexport = "1"
-StaticArrays = "1"

--- a/src/FirstPoincareInvariants/FirstPoincareInvariants.jl
+++ b/src/FirstPoincareInvariants/FirstPoincareInvariants.jl
@@ -2,8 +2,6 @@
 
 using OffsetArrays
 
-using GeometricIntegrators
-
 include("poincare_invariant_1st_common.jl")
 include("poincare_invariant_1st.jl")
 include("poincare_invariant_1st_canonical.jl")

--- a/src/FirstPoincareInvariants/poincare_invariant_1st.jl
+++ b/src/FirstPoincareInvariants/poincare_invariant_1st.jl
@@ -43,7 +43,7 @@ function PoincareInvariant1st(f_equ::Function, f_loop::Function, Θ::ΘT, Δt::T
 end
 
 
-function evaluate_poincare_invariant(pinv::PoincareInvariant1st, sol::Solution)
+function evaluate_poincare_invariant(pinv::PoincareInvariant1st, sol)
     p = zeros(size(sol.q[begin],1), size(sol.q,1), size(sol.q,2))
     g = zeros(size(sol.q[begin],1), size(sol.q,1), size(sol.q,2))
     v = zeros(size(sol.q[begin],1), size(sol.q,2))
@@ -73,7 +73,7 @@ function evaluate_poincare_invariant(pinv::PoincareInvariant1st, sol::Solution)
 end
 
 
-function write_to_hdf5(pinv::PoincareInvariant1st, sol::Solution, output_file::String)
+function write_to_hdf5(pinv::PoincareInvariant1st, sol, output_file::String)
     # h5open(output_file, isfile(output_file) ? "r+" : "w") do h5
     h5open(output_file, "w") do h5
 

--- a/src/FirstPoincareInvariants/poincare_invariant_1st_canonical.jl
+++ b/src/FirstPoincareInvariants/poincare_invariant_1st_canonical.jl
@@ -39,7 +39,7 @@ function PoincareInvariant1stCanonical(f_equ::Function, f_loop_q::Function, f_lo
 end
 
 
-function evaluate_poincare_invariant(pinv::PoincareInvariant1stCanonical, sol::SolutionPODE)
+function evaluate_poincare_invariant(pinv::PoincareInvariant1stCanonical, sol)
     v = zeros(size(sol.q[begin],1), size(sol.q,2))
 
     for i in axes(sol.q,1)
@@ -51,7 +51,7 @@ function evaluate_poincare_invariant(pinv::PoincareInvariant1stCanonical, sol::S
 end
 
 
-function write_to_hdf5(pinv::PoincareInvariant1stCanonical, sol::Solution, output_file::String)
+function write_to_hdf5(pinv::PoincareInvariant1stCanonical, sol, output_file::String)
     # h5open(output_file, isfile(output_file) ? "r+" : "w") do h5
     h5open(output_file, "w") do h5
         write(h5, "t", sol.t)

--- a/src/SecondPoincareInvariants/PaduaTransforms.jl
+++ b/src/SecondPoincareInvariants/PaduaTransforms.jl
@@ -5,7 +5,6 @@ an implementation of the Padua transform and its inverse via the fast Fourier tr
 """
 module PaduaTransforms
 
-using StaticArrays: SVector
 using FFTW
 using LinearAlgebra: rmul!
 

--- a/test/FirstPoincareInvariants/poincare_invariant_1st_tests.jl
+++ b/test/FirstPoincareInvariants/poincare_invariant_1st_tests.jl
@@ -1,6 +1,0 @@
-
-using PoincareInvariants
-using GeometricIntegrators
-using GeometricIntegrators.Utils
-using Test
-

--- a/test/FirstPoincareInvariants/poincare_invariant_1st_unittests.jl
+++ b/test/FirstPoincareInvariants/poincare_invariant_1st_unittests.jl
@@ -1,6 +1,0 @@
-
-using PoincareInvariants
-using GeometricIntegrators
-using GeometricIntegrators.Utils
-using Test
-

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,5 @@
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
StaticArrays can be removed without changing anything.

Both GeometricIntegrators and HDF5 will be dependencies of some kind in the future. When I get to that part of the implementation, we will have to figure out how exactly we want to integrate with both packages. For now my tests run twice as fast by removing them and no tested functionality depends on them.

In fact almost all functionality remains in tact, even considering the untested FirstPoincareInvariant functionality. Only reading and writing to HDF5 of the FirstPoincareInvariants won't work now, but we'll need to take another look at how to do that later anyway.