### PR TITLE
Rename ChebyshevImplementation to Chebyshev

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,10 +9,10 @@ DocMeta.setdocmeta!(
 )
 
 DocMeta.setdocmeta!(
-    PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms,
+    PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms,
     :DocTestSetup,
     quote
-        using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms
+        using PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms
     end
 )
 

--- a/docs/src/padua_transforms.md
+++ b/docs/src/padua_transforms.md
@@ -1,9 +1,9 @@
 # Padua Transforms
 
 ```@meta
-CurrentModule = PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms
+CurrentModule = PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms
 DocTestSetup = quote
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms
 end
 ```
 

--- a/src/SecondPoincareInvariants/Chebyshev.jl
+++ b/src/SecondPoincareInvariants/Chebyshev.jl
@@ -1,10 +1,10 @@
 """
-    ChebyshevImplementation
+    Chebyshev
 
 implementation of computation of second Poincare invariant by approximating surface with
 Chebyshev polynomials
 """
-module ChebyshevImplementation
+module Chebyshev
 
 using ...PoincareInvariants: @argcheck
 import ...PoincareInvariants: compute!, getpoints, getpointnum
@@ -181,4 +181,4 @@ getpoints(f::Function, plan::ChebyshevPlan) = getpaduapoints(plan.degree) do x, 
     f((x + 1) / 2, (y + 1) / 2)
 end
 
-end  # module ChebyshevImplementation
+end  # module Chebyshev

--- a/src/SecondPoincareInvariants/SecondPoincareInvariants.jl
+++ b/src/SecondPoincareInvariants/SecondPoincareInvariants.jl
@@ -10,7 +10,7 @@ export SecondPoincareInvariant
 
 ## Implementation(s)
 
-include("ChebyshevImplementation.jl")
+include("Chebyshev.jl")
 
 ## SecondPoincareInvariant ##
 
@@ -28,14 +28,14 @@ end
 
 function SecondPoincareInvariant{T}(Ω::ΩT, D::Integer, N::Integer) where {T, ΩT <: AbstractMatrix}
     @argcheck size(Ω) == (D, D) "Ω must be a $D × $D matrix"
-    plan = ChebyshevImplementation.ChebyshevPlan{T}(Ω, D, N)
+    plan = Chebyshev.ChebyshevPlan{T}(Ω, D, N)
     SecondPoincareInvariant{T, ΩT, typeof(plan)}(Ω, D, plan)
 end
 
 function SecondPoincareInvariant{T}(
     Ω::ΩT, D::Integer, N::Integer, ::Val{inplace}
 ) where {T, ΩT <: Callable, inplace}
-    plan = ChebyshevImplementation.ChebyshevPlan{T}(Ω, D, N, Val(inplace))
+    plan = Chebyshev.ChebyshevPlan{T}(Ω, D, N, Val(inplace))
     SecondPoincareInvariant{T, ΩT, typeof(plan)}(Ω, D, plan)
 end
 

--- a/test/SecondPoincareInvariants/test_Chebyshev.jl
+++ b/test/SecondPoincareInvariants/test_Chebyshev.jl
@@ -1,7 +1,7 @@
 @safetestset "PaduaTransforms" begin include("test_PaduaTransforms.jl") end
 
 @safetestset "Differentiation" begin
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation:
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev:
         DiffPlan, differentiate!
 
     @test DiffPlan{Float64}(5).D == [0  1  0  3  0   5;
@@ -53,7 +53,7 @@
 end
 
 @safetestset "Integration" begin
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation:
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev:
         getintegrator, integrate
 
     # integrating odd polynomials over symmetric boundary conditions gives 0
@@ -69,8 +69,8 @@ end
 end
 
 @safetestset "getintegrand! with OOPIntPlan" begin
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation:
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev:
         DiffPlan, differentiate!, OOPIntPlan, getintegrand!
     using PoincareInvariants.CanonicalSymplecticStructures
 
@@ -143,8 +143,8 @@ end
 end
 
 @safetestset "compute! with ChebyshevPlan (OOP)" begin
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation:
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev:
         ChebyshevPlan, compute!, DiffPlan
     using PoincareInvariants.CanonicalSymplecticStructures
 
@@ -190,8 +190,8 @@ end
 end
 
 @safetestset "getpoints and getpointnum" begin
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms
-    using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation:
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms
+    using PoincareInvariants.SecondPoincareInvariants.Chebyshev:
         ChebyshevPlan, getpoints, getpointnum
 
     Ω(v, t, p) = [0 -1; 1 0]

--- a/test/SecondPoincareInvariants/test_PaduaTransforms.jl
+++ b/test/SecondPoincareInvariants/test_PaduaTransforms.jl
@@ -1,4 +1,4 @@
-using PoincareInvariants.SecondPoincareInvariants.ChebyshevImplementation.PaduaTransforms
+using PoincareInvariants.SecondPoincareInvariants.Chebyshev.PaduaTransforms
 
 module ChebyshevTestUtils
     using LinearAlgebra: UpperTriangular

--- a/test/SecondPoincareInvariants/test_SecondPoincareInvariants.jl
+++ b/test/SecondPoincareInvariants/test_SecondPoincareInvariants.jl
@@ -1,4 +1,4 @@
-@safetestset "ChebyshevImplementation" begin include("test_ChebyshevImplementation.jl") end
+@safetestset "Chebyshev Implementation" begin include("test_Chebyshev.jl") end
 
 @safetestset "SecondPoincareInvariant OOP" begin
     using PoincareInvariants


### PR DESCRIPTION
`ChebyshevImplementation` works well enough as a name but `FiniteDifferencesImplementation` or `TrapzoidalImplementation` is just too long. It's always clear from context or folder structure that it's a particular implementation of the SecondPoincareInvariant so there's no way to confuse it.