### PR TITLE
Make dimension a type variable and use SVectors to represent points

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,10 @@ FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 FFTW = "1"
 OffsetArrays = "1"
+StaticArrays = "1"
 Reexport = "1"

--- a/docs/src/second_poincare_invariants.md
+++ b/docs/src/second_poincare_invariants.md
@@ -27,7 +27,7 @@ In future it will also be possible to use a constant matrix or an in-place funct
 Now, we can initialise the setup object used to calculate the invariant.
 
 ```jldoctest usage
-julia> pinv = SecondPoincareInvariant{Float64}(Ω, D, N);
+julia> pinv = SecondPoincareInvariant{Float64, D}(Ω, N);
 ```
 
 The type `Float64` specifies that the final result as well as all intermediate calculations will use the type `Float64`.

--- a/src/PoincareInvariants.jl
+++ b/src/PoincareInvariants.jl
@@ -7,7 +7,8 @@ module PoincareInvariants
 
 using Reexport
 
-export AbstractPoincareInvariant, compute!, getdim, getform, getpoints, getpointnum
+export AbstractPoincareInvariant, compute!, getdim, getform,
+    getpoints, getpointspec, getpointnum
 
 """
     AbstractPoincareInvariant
@@ -32,11 +33,21 @@ so as to `compute!` `pinv`.
 function getpoints end
 
 """
+    getpointspec(pinv::AbstractPoincareInvariant)
+
+get point specification, which may, for example, be a tuple specifying a grid or
+a number giving the number of points used to sample in phase space.
+"""
+getpointspec(ps, P) = getpointnum(ps)
+# falls back to giving number of points
+
+"""
     getpointnum(pinv::AbstractPoincareInvariant)
 
 returns number of points to sample in phase space to `compute!` `pinv`.
 """
-function getpointnum end
+getpointnum(pinv::AbstractPoincareInvariant) = getpointnum(getpointspec(pinv))
+getpointnum(N::Integer) = N
 
 """
     getdim(pinv::AbstractPoincareInvariant)

--- a/src/SecondPoincareInvariants/Chebyshev.jl
+++ b/src/SecondPoincareInvariants/Chebyshev.jl
@@ -6,8 +6,7 @@ Chebyshev polynomials
 """
 module Chebyshev
 
-import ...PoincareInvariants: compute!, getpoints, getpointnum
-import ..SecondPoincareInvariants: getpointspec
+import ...PoincareInvariants: compute!, getpoints, getpointspec
 
 using ...PoincareInvariants: @argcheck
 using ..SecondPoincareInvariants: SecondPoincareInvariant
@@ -76,7 +75,7 @@ integrate(coeffs, intweights) = dot(intweights, coeffs, intweights)
 
 ## getintegrand for Ω Callable and out-of-place ##
 
-struct CallIntPlan{T, IP, P}
+struct CallIntPlan{T, D, IP, P}
     invpaduaplan::IP
     phasevals::Matrix{T}
     ∂xvals::Matrix{T}
@@ -85,7 +84,7 @@ struct CallIntPlan{T, IP, P}
     paduaplan::P
 end
 
-function CallIntPlan{T}(D, degree) where T
+function CallIntPlan{T, D}(degree) where {T, D}
     invpaduaplan = InvPaduaTransformPlan{T}(degree)
     phasevals = Matrix{T}(undef, D, getpaduanum(degree))
     ∂xvals = Matrix{T}(undef, D, getpaduanum(degree))
@@ -93,19 +92,18 @@ function CallIntPlan{T}(D, degree) where T
     intvals = Vector{T}(undef, getpaduanum(degree))
     paduaplan = PaduaTransformPlan{T}(degree)
 
-    CallIntPlan{T, typeof(invpaduaplan), typeof(paduaplan)}(
+    CallIntPlan{T, D, typeof(invpaduaplan), typeof(paduaplan)}(
         invpaduaplan, phasevals, ∂xvals, ∂yvals, intvals, paduaplan
     )
 end
 
 function getintegrand!(
-    intcoeffs::AbstractMatrix, plan::CallIntPlan{T}, Ω::Callable,
+    intcoeffs::AbstractMatrix, plan::CallIntPlan{T, D}, Ω::Callable,
     phasepoints, t, p, ∂xcoeffs, ∂ycoeffs
-) where T
+) where {T, D}
     invpaduatransform!(eachrow(plan.∂xvals), plan.invpaduaplan, ∂xcoeffs)
     invpaduatransform!(eachrow(plan.∂yvals), plan.invpaduaplan, ∂ycoeffs)
 
-    D = length(phasepoints)
     for d in 1:D
         plan.phasevals[d, :] .= phasepoints[d]
     end
@@ -124,10 +122,10 @@ end
 
 ## ChebyshevPlan and compute! ##
 
-getintplan(::Type{T}, ::Callable, D, degree) where T = CallIntPlan{T}(D, degree)
+getintplan(::Type{T}, ::Callable, ::Val{D}, degree) where {T, D} = CallIntPlan{T, D}(degree)
 # getintplan(::Type{T}, Ω::AbstractMatrix, D, degree) where T = ConstIntPlan{T}(Ω, D, degree)
 
-struct ChebyshevPlan{T, IP, PP<:PaduaTransformPlan}
+struct ChebyshevPlan{T, D, IP, PP<:PaduaTransformPlan}
     degree::Int
     paduaplan::PP
     phasecoeffs::Vector{Matrix{T}}
@@ -139,7 +137,7 @@ struct ChebyshevPlan{T, IP, PP<:PaduaTransformPlan}
     intweights::Vector{T}
 end
 
-function ChebyshevPlan{T}(Ω::Callable, D::Integer, N::Integer) where T
+function ChebyshevPlan{T, D}(Ω::Callable, N::Integer) where {T, D}
     degree = getdegree(nextpaduanum(N))
 
     paduaplan = PaduaTransformPlan{T}(degree)
@@ -147,18 +145,18 @@ function ChebyshevPlan{T}(Ω::Callable, D::Integer, N::Integer) where T
     diffplan = DiffPlan{T}(degree)
     ∂x = [Matrix{T}(undef, degree+1, degree+1) for _ in 1:D]
     ∂y = [Matrix{T}(undef, degree+1, degree+1) for _ in 1:D]
-    intplan = getintplan(T, Ω, D, degree)
+    intplan = getintplan(T, Ω, Val(D), degree)
     intcoeffs = zeros(T, degree+1, degree+1)
     intweights = getintweights(T, degree)
 
-    ChebyshevPlan{T, typeof(intplan), typeof(paduaplan)}(
+    ChebyshevPlan{T, D, typeof(intplan), typeof(paduaplan)}(
         degree, paduaplan, phasecoeffs, diffplan, ∂x, ∂y, intplan, intcoeffs, intweights
     )
 end
 
 function compute!(
-    pinv::SecondPoincareInvariant{T, ΩT, NT, P}, phasepoints, t, p
-) where {T, ΩT <: Callable, NT, P <: ChebyshevPlan}
+    pinv::SecondPoincareInvariant{<:Any, <:Any, ΩT, <:Any, P}, phasepoints, t, p
+) where {ΩT <: Callable, P <: ChebyshevPlan}
     plan = pinv.plan
     paduatransform!(plan.phasecoeffs, plan.paduaplan, phasepoints)
     differentiate!(plan.∂x, plan.∂y, plan.diffplan, plan.phasecoeffs)
@@ -175,11 +173,11 @@ end
 
 ## getpoints, getpointspec and getpointnum ##
 
-getpointnum(N::Integer, ::Type{<:ChebyshevPlan}) = nextpaduanum(N)
-getpointnum(dims::NTuple{2, Integer}, ::Type{<:ChebyshevPlan}) = nextpaduanum(dims[1] * dims[2])
+getpointspec(N::Integer, ::Type{<:ChebyshevPlan}) = nextpaduanum(N)
+getpointspec((nx, ny)::NTuple{2, Integer}, ::Type{<:ChebyshevPlan}) = nextpaduanum(nx * ny)
 
 function getpoints(f, ::Type{T}, N, ::Type{<:ChebyshevPlan}) where T
-    degree = nextdegree(N)
+    degree = getdegree(getpointspec(N, ChebyshevPlan))
     return getpaduapoints(T, degree) do x, y
         f((x + T(1)) / T(2), (y + T(1)) / T(2))
     end

--- a/src/SecondPoincareInvariants/FiniteDifferences.jl
+++ b/src/SecondPoincareInvariants/FiniteDifferences.jl
@@ -1,18 +1,20 @@
 module FiniteDifferences
 
-using LinearAlgebra: dot
+import ...PoincareInvariants: compute!, getpoints, getpointnum, getpointspec
+import ..SecondPoincareInvariants: SecondPoincareInvariant
+
 using ...PoincareInvariants: @argcheck
 
-import ...PoincareInvariants: compute!, getpoints, getpointnum
-import ..SecondPoincareInvariants: SecondPoincareInvariant, getpointspec
+using LinearAlgebra: dot
+using Base: Callable
 
-struct FiniteDiffPlan{T}
+struct FiniteDiffPlan{T, D}
     ∂x::Vector{Vector{T}}
     ∂y::Vector{Vector{T}}
     simpweights::Vector{T}
 end
 
-function FiniteDiffPlan{T}(Ω, D::Integer, ps::NTuple{2, Int}) where T
+function FiniteDiffPlan{T, D}(Ω, ps::NTuple{2, Int}) where {T, D}
     nx, ny = ps
     N = nx * ny
 
@@ -20,12 +22,12 @@ function FiniteDiffPlan{T}(Ω, D::Integer, ps::NTuple{2, Int}) where T
     ∂y = [Vector{T}(undef, N) for _ in 1:D]
     simpweights = getsimpweights(T, nx, ny)
 
-    FiniteDiffPlan{T}(∂x, ∂y, simpweights)
+    FiniteDiffPlan{T, D}(∂x, ∂y, simpweights)
 end
 
 function compute!(
-    pinv::SecondPoincareInvariant{T, ΩT, PS, P}, phasepoints, t, p
-) where {T, ΩT, PS, P <: FiniteDiffPlan}
+    pinv::SecondPoincareInvariant{T, D, ΩT, <:Any, P}, phasepoints, t, p
+) where {T, D, ΩT<:Callable, P <: FiniteDiffPlan}
     nx, ny = pinv.pointspec
     N = nx * ny
 
@@ -33,15 +35,15 @@ function compute!(
 
     # These should probably be static vectors, but that requires making
     # the dimension of the phase space a type variable
-    ∂xi = Vector{T}(undef, pinv.D)
-    ∂yi = Vector{T}(undef, pinv.D)
-    pnti = Vector{T}(undef, pinv.D)
+    ∂xi = Vector{T}(undef, D)
+    ∂yi = Vector{T}(undef, D)
+    pnti = Vector{T}(undef, D)
 
     I = zero(T)
     w = pinv.plan.simpweights
 
     @inbounds for i in 1:N
-        for d in 1:pinv.D
+        for d in 1:D
             ∂xi[d] = pinv.plan.∂x[d][i]
             ∂yi[d] = pinv.plan.∂y[d][i]
             pnti[d] = phasepoints[d][i]
@@ -55,12 +57,7 @@ end
 
 ## getpoints, getpointnum and getpointspec ##
 
-function getpointnum(dims::NTuple{2, Integer}, ::Type{<:FiniteDiffPlan})
-    nx, ny = getpointspec(dims, FiniteDiffPlan)
-    return nx * ny
-end
-
-getpointnum(N, ::Type{T}) where T <: FiniteDiffPlan = getpointnum(getpointspec(N, T), T)
+getpointnum((nx, ny)::NTuple{2, Integer}) = nx * ny
 
 nextodd(n::Integer)::Int = n <= 3 ? 3 : 2 * fld(n, 2) + 1
 

--- a/test/SecondPoincareInvariants/test_Chebyshev.jl
+++ b/test/SecondPoincareInvariants/test_Chebyshev.jl
@@ -54,8 +54,7 @@ using PoincareInvariants.SecondPoincareInvariants.Chebyshev
 end
 
 @safetestset "Integration" begin
-    using ..Chebyshev:
-        getintweights, integrate
+    using ..Chebyshev: getintweights, integrate
 
     # integrating odd polynomials over symmetric boundary conditions gives 0
     @test all(getintweights(100)[2:2:end] .== 0)
@@ -71,8 +70,7 @@ end
 
 @safetestset "getintegrand! with CallIntPlan" begin
     using ..Chebyshev.PaduaTransforms
-    using ..Chebyshev:
-        DiffPlan, differentiate!, CallIntPlan, getintegrand!
+    using ..Chebyshev: DiffPlan, differentiate!, CallIntPlan, getintegrand!
     using PoincareInvariants.CanonicalSymplecticStructures
 
     @testset "6 Points in 2 Dimensions" begin
@@ -97,7 +95,7 @@ end
 
         Ω(v, t, p) = [0 -1; 1  0]
 
-        plan = CallIntPlan{Float64}(D, degree)
+        plan = CallIntPlan{Float64, D}(degree)
 
         intcoeffs = zeros(degree+1, degree+1)
 
@@ -130,7 +128,7 @@ end
 
         Ω(v, t, p) = CanonicalSymplecticMatrix(D)
 
-        plan = CallIntPlan{Float64}(D, degree)
+        plan = CallIntPlan{Float64, D}(degree)
 
         intcoeffs = zeros(degree+1, degree+1)
 
@@ -149,13 +147,12 @@ end
     using PoincareInvariants.SecondPoincareInvariants
     using PoincareInvariants.CanonicalSymplecticStructures
 
-
     D = 12
     N = 200
     Ω(v, t, p) = CanonicalSymplecticMatrix(D)
     pointnum = nextpaduanum(N)
     degree = getdegree(pointnum)
-    plan = ChebyshevPlan{Float64}(Ω, D, pointnum)
+    plan = ChebyshevPlan{Float64, D}(Ω, pointnum)
 
     testphasecoeffs = [zeros(degree+1, degree+1) for _ in 1:D]
     test∂x = [zeros(degree+1, degree+1) for _ in 1:D]
@@ -170,7 +167,7 @@ end
         end
     end
 
-    pinv = SecondPoincareInvariant{Float64}(Ω, D, pointnum, plan)
+    pinv = SecondPoincareInvariant{Float64, D}(Ω, pointnum, plan)
     @test compute!(pinv, phasepoints, 0, nothing) ≈ 4 atol=20eps()
 
     testphasecoeffs[1][1, 2] = 1  # 1 x
@@ -192,15 +189,11 @@ end
 
 @safetestset "getpoints, getpointspec and getpointnum" begin
     using ..Chebyshev.PaduaTransforms
-    using ..Chebyshev: ChebyshevPlan, getpoints, getpointnum
-    using PoincareInvariants.SecondPoincareInvariants: getpointspec
+    using ..Chebyshev: ChebyshevPlan, getpointspec, getpoints
 
     for N in [10, 321, 2178], T in [Float32, Float64]
         @test getpointspec(N, ChebyshevPlan) == nextpaduanum(N)
         @test getpointspec((N, 2N), ChebyshevPlan) == nextpaduanum(N * 2N)
-
-        @test getpointnum(N, ChebyshevPlan) == nextpaduanum(N)
-        @test getpointnum((7, N), ChebyshevPlan) == nextpaduanum(7 * N)
 
         f(x, y) = 5 * x, cos(x*y), x+y
         rescale(x, y) = ((x, y) .+ 1) ./ 2

--- a/test/SecondPoincareInvariants/test_Chebyshev.jl
+++ b/test/SecondPoincareInvariants/test_Chebyshev.jl
@@ -89,7 +89,7 @@ end
         ∂ycoeffs = ntuple(_ -> zeros(degree+1, degree+1), D)
         differentiate!(∂xcoeffs, ∂ycoeffs, DiffPlan{Float64}(degree), phasecoeffs)
 
-        phasepoints = [Vector{Float64}(undef, getpaduanum(degree)) for _ in 1:D]
+        phasepoints = ntuple(_ -> Vector{Float64}(undef, getpaduanum(degree)), D)
         iplan = InvPaduaTransformPlan{Float64}(degree)
         invpaduatransform!(phasepoints, iplan, phasecoeffs)
 

--- a/test/SecondPoincareInvariants/test_FiniteDifferences.jl
+++ b/test/SecondPoincareInvariants/test_FiniteDifferences.jl
@@ -7,13 +7,9 @@ using PoincareInvariants.SecondPoincareInvariants.FiniteDifferences
     @test getpointspec(87, FiniteDiffPlan) == (11, 11)
     @test getpointspec((53, 42), FiniteDiffPlan) == (53, 43)
 
-    @test getpointnum(50, FiniteDiffPlan) == 81
-    @test getpointnum(87, FiniteDiffPlan) == 121
-    @test getpointnum(400, FiniteDiffPlan) == 441
-
-    @test getpointnum((3, 5), FiniteDiffPlan) == 15
-    @test getpointnum((423789, 326), FiniteDiffPlan) == 423789 * 327
-    @test getpointnum((123, 908342), FiniteDiffPlan) == 123 * 908343
+    @test getpointnum((3, 5)) == 15
+    @test getpointnum((423789, 326)) == 423789 * 326
+    @test getpointnum((123, 908343)) == 123 * 908343
 
     @inferred NTuple{3, Vector{Float64}} getpoints((x, y) -> (x, y, x+y), Float64, (7, 5), FiniteDiffPlan)
     @inferred Vector{Float32} getpoints((x, y) -> sin(x), Float32, (9, 9), FiniteDiffPlan)
@@ -70,7 +66,7 @@ using PoincareInvariants.SecondPoincareInvariants.FiniteDifferences
     end
     @test pnts4 isa NTuple{4, Vector{Float64}}
     @test all(pnts4) do v
-        length(v) == getpointnum(ps, FiniteDiffPlan)
+        length(v) == getpointnum(ps)
     end
 
     @test pnts4[1] ≈ testpnts[1]
@@ -231,7 +227,7 @@ end
 
     testI = dot(getsimpweights(Float64, dims...), integrand)
 
-    pinv = SecondPoincareInvariant{Float64}(Ω, 4, (11, 17), FiniteDiffPlan)
+    pinv = SecondPoincareInvariant{Float64, 4}(Ω, (11, 17), FiniteDiffPlan)
 
     @test pinv.plan isa FiniteDiffPlan
 
@@ -243,5 +239,5 @@ end
         @test pinv.plan.∂y[i] ≈ getpoints(fy, Float64, dims, FiniteDiffPlan)[i]
     end
 
-    @test I ≈ testI rtol=100eps()
+    @test I ≈ testI atol=5e-11
 end

--- a/test/SecondPoincareInvariants/test_SecondPoincareInvariants.jl
+++ b/test/SecondPoincareInvariants/test_SecondPoincareInvariants.jl
@@ -4,6 +4,21 @@
     include("test_FiniteDifferences.jl")
 end
 
+@safetestset "Interface" begin
+    @safetestset "Basic properties" begin
+        using PoincareInvariants
+
+        D = 6; N = 123
+        Ω(z, t, p) = CanonicalSymplecticMatrix(D)
+        pinv = SecondPoincareInvariant{Float64, D}(Ω, N)
+
+        @test getdim(pinv) == 6
+        @test N <= getpointnum(pinv) <= 2N
+        @test getpointspec(pinv) == getpointspec(N, typeof(pinv.plan)) == pinv.pointspec
+        @test getform(pinv) === pinv.Ω === Ω
+    end
+end
+
 @safetestset "One by One Square" begin
     using PoincareInvariants
     using PoincareInvariants.SecondPoincareInvariants.Chebyshev: ChebyshevPlan
@@ -12,17 +27,17 @@ end
     D = 2
     Ω(z, t, p) = CanonicalSymplecticMatrix(D)
 
-    let pinv = SecondPoincareInvariant{Float64}(Ω, D, 432)
+    let pinv = SecondPoincareInvariant{Float64, D}(Ω, 432)
         I = compute!(pinv, getpoints(pinv), 0, nothing)
         @test abs(1 - I) / eps() < 10
     end
 
-    let pinv = SecondPoincareInvariant{Float64}(Ω, D, 567, ChebyshevPlan)
+    let pinv = SecondPoincareInvariant{Float64, D}(Ω, 567, ChebyshevPlan)
         I = compute!(pinv, getpoints(pinv), 0, nothing)
         @test abs(1 - I) / eps() < 10
     end
 
-    let pinv = SecondPoincareInvariant{Float64}(Ω, D, (35, 75), FiniteDiffPlan)
+    let pinv = SecondPoincareInvariant{Float64, D}(Ω, (35, 75), FiniteDiffPlan)
         I = compute!(pinv, getpoints(pinv), 0, nothing)
         @test abs(1 - I) / eps() < 10
     end
@@ -52,15 +67,15 @@ end
         x + y
     )
 
-    Idefault = let pinv = PI2{Float64}(Ω, D, 1_000)
+    Idefault = let pinv = PI2{Float64, D}(Ω, 1_000)
         compute!(pinv, getpoints(f, pinv), 5, 11)
     end
 
-    Icheb = let pinv = PI2{Float64}(Ω, D, 1_000, ChebyshevPlan)
+    Icheb = let pinv = PI2{Float64, D}(Ω, 1_000, ChebyshevPlan)
         compute!(pinv, getpoints(f, pinv), 5, 11)
     end
 
-    Ifindiff = let pinv = PI2{Float64}(Ω, D, (31, 33), FiniteDiffPlan)
+    Ifindiff = let pinv = PI2{Float64, D}(Ω, (31, 33), FiniteDiffPlan)
         compute!(pinv, getpoints(f, pinv), 5, 11)
     end
 
@@ -74,8 +89,8 @@ end
         using PoincareInvariants.SecondPoincareInvariants: FiniteDiffPlan
 
         Ω(z, t, p) = CanonicalSymplecticMatrix(2)
-        pinv1 = PI2{Float64}(Ω, 2, 1_000)
-        pinv2 = PI2{Float64}(Ω, 2, 1_000, FiniteDiffPlan)
+        pinv1 = PI2{Float64, 2}(Ω, 1_000)
+        pinv2 = PI2{Float64, 2}(Ω, 1_000, FiniteDiffPlan)
 
         A = [1 5;
              0 1]
@@ -93,8 +108,8 @@ end
         using PoincareInvariants.SecondPoincareInvariants: FiniteDiffPlan
 
         Ω(z, t, p) = CanonicalSymplecticMatrix(8)
-        pinv1 = PI2{Float64}(Ω, 8, 1_000)
-        pinv2 = PI2{Float64}(Ω, 8, 1_000, FiniteDiffPlan)
+        pinv1 = PI2{Float64, 8}(Ω, 1_000)
+        pinv2 = PI2{Float64, 8}(Ω, 1_000, FiniteDiffPlan)
 
         A = CanonicalSymplecticMatrix(8)
 
@@ -129,8 +144,8 @@ end
     using PoincareInvariants.SecondPoincareInvariants: FiniteDiffPlan
 
     Ω(z, t, p) = CanonicalSymplecticMatrix(4)
-    pinv1 = PI2{Float64}(Ω, 4, 1_000)
-    pinv2 = PI2{Float64}(Ω, 4, 1_000, FiniteDiffPlan)
+    pinv1 = PI2{Float64, 4}(Ω, 1_000)
+    pinv2 = PI2{Float64, 4}(Ω, 1_000, FiniteDiffPlan)
 
     init(x, y) = (x, -x, y, -y)
     henon(q, p, a) = (p + a - q^2, -q)


### PR DESCRIPTION
Since I'm no longer using a matrix to represent the points and derivatives and such, I can't use views into rows or columns to represent points. Instead I'm now using a SVector, which is the natural way to represent points in Julia. To use SVectors, I needed to make the dimension a part of the type of the PoincareInvariant.